### PR TITLE
Move timestepping to submodule

### DIFF
--- a/fenics_helpers/timestepping/__init__.py
+++ b/fenics_helpers/timestepping/__init__.py
@@ -1,0 +1,1 @@
+from .timestepping import *

--- a/fenics_helpers/timestepping/timestepping.py
+++ b/fenics_helpers/timestepping/timestepping.py
@@ -2,6 +2,7 @@ import numpy as np
 from dolfin import Function, info
 import math
 
+__all__ = ["TimeStepper"]
 
 TERM_COLOR = {"red": "\033[31", "green": "\033[32"}
 


### PR DESCRIPTION
Previously, `import fenicshelper.timstepping` would also have things like `Function` and `math` in its namespace. Now, it only includes the `TimeStepper` class. Unfortunately, I couldn't find a way to achieve this w/o the extra directory.