### PR TITLE
Pass timestep to solve() function

### DIFF
--- a/fenics_helpers/timestepping/timestepping.py
+++ b/fenics_helpers/timestepping/timestepping.py
@@ -124,7 +124,7 @@ class TimeStepper:
 
             t += dt
 
-            num_iter, converged = self._solve(t)
+            num_iter, converged = self._solve(t, dt)
             assert isinstance(converged, bool)
             assert type(num_iter) == int  # isinstance(False, int) is True...
 
@@ -164,7 +164,7 @@ class TimeStepper:
         points_in_time = np.append(points_in_time, checkpoints)
 
         for t in np.sort(np.unique(points_in_time)):
-            num_iter, converged = self._solve(t)
+            num_iter, converged = self._solve(t, dt)
             assert isinstance(converged, bool)
 
             if converged:


### PR DESCRIPTION
In addition to `t`, this will pass `dt` to the `solve()` function. The build failures are due to hypothesis being upgraded to 4.13, and now testing additional checkpoints and some such. With the previous version (in my case 4.5) the tests would run.