### PR TITLE
Boundary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,4 @@ jobs:
           name: run tests
           command: |
               pip3 install --user hypothesis tqdm
-              cd tests && python3 -m unittest discover
+              cd tests && python3 -m unittest discover -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ before_script:
 
 script:
     - docker exec dock bash -c "pip3 install --user hypothesis tqdm"
-    - docker exec dock bash -c "cd shared/tests && python3 -m unittest discover"
+    - docker exec dock bash -c "cd shared/tests && python3 -m unittest discover -v"

--- a/fenics_helpers/__init__.py
+++ b/fenics_helpers/__init__.py
@@ -1,2 +1,3 @@
 from . import timestepping
 from . import plotting
+from . import boundary

--- a/fenics_helpers/boundary/__init__.py
+++ b/fenics_helpers/boundary/__init__.py
@@ -1,0 +1,1 @@
+from .boundary import *

--- a/fenics_helpers/boundary/boundary.py
+++ b/fenics_helpers/boundary/boundary.py
@@ -1,0 +1,60 @@
+from dolfin import SubDomain
+
+def plane_at(coordinate, dim=0, eps=1.e-10):
+    """
+    Creates a dolfin.SubDomain that only contains boundaries
+    that lay on the plane where the `dim`-th dimension equals
+    `coordinate` (within a tolerance `eps`).
+    """
+    if dim in ["x", "X"]:
+        dim = 0
+    if dim in ["y", "Y"]:
+        dim = 1
+    if dim in ["z", "Z"]:
+        dim = 2
+
+    assert dim in [0, 1, 2]
+
+    class B(SubDomain):
+        def inside(self, x, on_boundary):
+            return on_boundary and near(x[dim], value, eps)
+
+    return B()
+
+
+
+def within_range(start, end, eps=1.0e-10):
+    """
+    Creates a dolfin.SubDomain that only contains boundaries
+    that lay within `start` << x << `end`. `start` and `end`
+    must match the spatial dimension and may contain multiple
+    values. 
+    """
+    if isnumber(start):
+        start = [start]
+    
+    if isnumber(end):
+        start = [end]
+
+    assert len(start) == len(end)
+    for i in range(len(start)):
+        assert start[i] <= end[i]
+
+    class B(dolfin.SubDomain):
+        def inside(self, x, on_boundary):
+            b = on_boundary
+
+            assert len(start) == len(end) == len(x)
+            for i in range(len(x)):
+                b = b and start[i] - eps < x[i] < end[i] + eps
+            return b
+
+    return B()
+
+def point_at(p, eps=1.0e-10):
+    """
+    Creates a dolfin.SubDomain that only contains boundary points that 
+    are near `p` (within a tolerance `eps`).
+    """
+    return within_range(p, p, eps)
+

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -1,0 +1,42 @@
+import unittest
+from context import fenics_helpers
+from fenics_helpers import boundary
+
+class TestBoundary(unittest.TestCase):
+    def test_plane_at(self):
+        b = boundary.plane_at(0, "Y")
+        self.assertTrue(b.inside([0,0], True))
+        self.assertTrue(b.inside([42,0,42], True))
+        self.assertFalse(b.inside([0,1], True))
+        self.assertFalse(b.inside([0,0], False))
+       
+        with self.assertRaises(Exception):
+            b.inside([0], True)
+
+    def test_within_range_1D(self):
+        b = boundary.within_range(-5, -3)
+        self.assertTrue(b.inside([-4], True))
+        self.assertFalse(b.inside([42], True))
+
+    def test_within_range_3D(self):
+        with self.assertRaises(Exception):
+            b = boundary.within_range([0,0], [1,1,1])
+        with self.assertRaises(Exception):
+            b = boundary.within_range([0,0,0], [1,1])
+        with self.assertRaises(Exception):
+            b = boundary.within_range(0, [1,1])
+
+        b = boundary.within_range([0,1,0], [1,0,1])
+        self.assertTrue(b.inside([0.5, 0.5, 0.5], True))
+        self.assertFalse(b.inside([1.5, 0.5, 0.5], True))
+        self.assertFalse(b.inside([0.5, 1.5, 0.5], True))
+        self.assertFalse(b.inside([0.5, 0.5, 1.5], True))
+
+    def test_point_at(self):
+        b = boundary.point_at([0,0])
+        self.assertTrue(b.inside([0,0], True))
+        self.assertFalse(b.inside([0,0], False))
+        self.assertFalse(b.inside([1,0], True))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Boundary selection is a bit of boilerplate. In the simplest case, you define a `isinside`-like method. If you want to mark that boundary, you need to subclass `dolfin.SubDdomain` and put that method in there.

To simplify that stuff, you can now call
~~~py
from fenics_helpers import boundary
left   = boundary.plane_at(0, "x")
right  = boundary.plane_at(L)  # second argument defaults to "x"
origin = boundary.point_at([0,0])
hole   = boundary.within_range([0.2, 0.2], [0.4, 0.4])
~~~ 
All the objects are `dolfin.SubDomains`.