### PR TITLE
Ignore 'on_boundary' argument for 'point_at'

### DIFF
--- a/fenics_helpers/boundary.py
+++ b/fenics_helpers/boundary.py
@@ -73,5 +73,18 @@ def point_at(p, eps=1.0e-10):
     """
     Creates a dolfin.SubDomain that only contains boundary points that 
     are near `p` (within a tolerance `eps`).
+
+    Corresponding FEniCS DirichletBCs have to be applied with
+    method="pointwise", which somehow passes "on_boundary=False". Thus, we
+    ignore the on_boundary argument.
     """
-    return within_range(p, p, eps)
+
+    class B(SubDomain):
+        def inside(self, x, on_boundary):
+            assert len(p) == len(x)
+            for i in range(len(x)):
+                if not p[i] - eps < x[i] < p[i] + eps:
+                    return False
+            return True
+
+    return B()

--- a/fenics_helpers/boundary.py
+++ b/fenics_helpers/boundary.py
@@ -82,9 +82,6 @@ def point_at(p, eps=1.0e-10):
     class B(SubDomain):
         def inside(self, x, on_boundary):
             assert len(p) == len(x)
-            for i in range(len(x)):
-                if not p[i] - eps < x[i] < p[i] + eps:
-                    return False
-            return True
+            return all(near(x_i, p_i, eps) for x_i, p_i in zip(x, p))
 
     return B()

--- a/tests/test_boundary.py
+++ b/tests/test_boundary.py
@@ -34,7 +34,7 @@ class TestBoundary(unittest.TestCase):
     def test_point_at(self):
         b = boundary.point_at([0,0])
         self.assertTrue(b.inside([0,0], True))
-        self.assertFalse(b.inside([0,0], False))
+        self.assertTrue(b.inside([0,0], False))
         self.assertFalse(b.inside([1,0], True))
 
 if __name__ == "__main__":


### PR DESCRIPTION
FEniCS DirichletBCs with "point_at" have to be applied with
method="pointwise", which somehow passes "on_boundary=False". Thus, we
ignore the on_boundary argument.