### PR TITLE
scipy deprecation warning in rk.py

### DIFF
--- a/fenics_helpers/rk.py
+++ b/fenics_helpers/rk.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Runge Kutta methods."""
 import numpy as np
-from scipy import array, sqrt
+from numpy import array
+from numpy.lib.scimath import sqrt
 
 import dolfin as d
 import ufl


### PR DESCRIPTION
use numpy.array and numpy.lib.scimath.sqrt instead of scipy.array and scipy.sqrt due to DeprecationWarning that these will be removed in scipy version 2.0.0