### PR TITLE
Fix storage of u_prev to keep links to previously defined subfunctions

### DIFF
--- a/fenics_helpers/timestepping.py
+++ b/fenics_helpers/timestepping.py
@@ -100,7 +100,7 @@ class TimeStepper:
         if dt is None:
             dt = self._dt_max
 
-        u_prev = self._u.copy(deepcopy=True)
+        u_prev = self._u.vector().get_local() + 0.0
         t = t_start
         self._post_process(t)
 
@@ -127,7 +127,7 @@ class TimeStepper:
 
             if converged:
                 progress.success(t, dt, num_iter)
-                u_prev.assign(self._u)
+                u_prev[:] = self._u.vector().get_local()[:]
                 self._post_process(t)
 
                 # increase the time step for fast convergence
@@ -140,7 +140,7 @@ class TimeStepper:
             else:
                 progress.error(t, dt, num_iter)
 
-                self._u.assign(u_prev)
+                self._u.vector().set_local(u_prev)
                 t -= dt
 
                 dt0 *= self.decrease_factor

--- a/fenics_helpers/timestepping.py
+++ b/fenics_helpers/timestepping.py
@@ -100,7 +100,7 @@ class TimeStepper:
         if dt is None:
             dt = self._dt_max
 
-        u_prev = self._u.vector().get_local() + 0.0
+        u_prev = self._u.vector().get_local()
         t = t_start
         self._post_process(t)
 


### PR DESCRIPTION
The storage of `u_prev` within the adaptive time stepping uses `df.Function.copy` and apparently destroys the link between references to the original function, see https://github.com/BAMresearch/fenics_helpers/blob/u_prev_assignment/tests/test_timestepping.py#L174-L175

@ajafarihub Please fix :stuck_out_tongue: 